### PR TITLE
CSS formulaire login & résolution CSS account

### DIFF
--- a/src/MainBundle/Resources/views/App/account.html.twig
+++ b/src/MainBundle/Resources/views/App/account.html.twig
@@ -10,20 +10,6 @@
 
 {% block head %}
     {{ parent() }}
-    <div class="loginBlock">
-        <form>
-            <div class="loginUsernamePassword">
-                <input/>
-                <input/>
-            </div>
-
-            <div class="loginConnectionForgot">
-                <button>{{ 'Connection'|trans }}</button>
-                <em><a>{{ 'Forgot your account\'s password ?'|trans }}</a></em>
-            </div>
-
-        </form>
-    </div>
 {% endblock %}
 
 {% block stylesheets %}

--- a/src/MainBundle/Resources/views/Layout/accountBlock.html.twig
+++ b/src/MainBundle/Resources/views/Layout/accountBlock.html.twig
@@ -2,7 +2,7 @@
     <div class="accountName">
         username
     </div>
-    <div class=accountNotification">
+    <div class="accountNotification">
         <a>{{ "Notifications"|trans }}</a>
         <a>{{ "Account"|trans }}</a>
     </div>

--- a/src/MainBundle/Resources/views/Layout/loginBlock.html.twig
+++ b/src/MainBundle/Resources/views/Layout/loginBlock.html.twig
@@ -5,7 +5,6 @@
         </div>
 
         <div class="loginConnectionForgot">
-            <button>{{ 'Connection'|trans }}</button>
             <em><a>{{ 'Forgot your account\'s password ?'|trans }}</a></em>
         </div>
 

--- a/web/public/css/style.css
+++ b/web/public/css/style.css
@@ -14,7 +14,7 @@ html {
 Style pour le header du site (header.html.twig)
 ----------------------------------------------------------------------*/
 
-.header {
+header {
     margin: 15px 50px;
 }
 
@@ -43,7 +43,7 @@ Style pour le header du site (header.html.twig)
     font-weight: bolder;
 }
 
-.userName {
+.accountName {
     flex: 1;
     display: flex;
     align-items: center;
@@ -92,6 +92,10 @@ Style pour le header du site (header.html.twig)
 .loginUsernamePassword {
     display: flex;
     flex-direction: column;
+}
+
+.loginUsernamePassword div:nth-child(2) {
+    display: none;
 }
 
 .loginConnectionForgot a {


### PR DESCRIPTION
_Ajout du CSS pour le formulaire FOS de login
_Résolution d'un problème de class entre le style.css et
accountBlock.html.twig
_Suppression du formulaire de login en doublon dans account.html.twig